### PR TITLE
#Fix keyboard pop up problem.

### DIFF
--- a/Example/BABFrameObservingInputAccessoryView/BABViewController.m
+++ b/Example/BABFrameObservingInputAccessoryView/BABViewController.m
@@ -35,7 +35,8 @@
     
     inputView.keyboardFrameChangedBlock = ^(BOOL keyboardVisible, CGRect keyboardFrame){
         
-        CGFloat value = CGRectGetHeight(weakSelf.view.frame) - CGRectGetMinY(keyboardFrame);
+        //Adjust the offset for different situation, e.g: personal hotspot.. etc
+        CGFloat value = CGRectGetHeight([[UIScreen mainScreen] bounds]) - CGRectGetMinY(keyboardFrame);
         weakSelf.toolbarContainerVerticalSpacingConstraint.constant = MAX(0, value);
         [weakSelf.view layoutIfNeeded];
         


### PR DESCRIPTION
Fix layout problem: "weakSelf.view"  can't :get the accurate height of screen.
If users view have multi-layer, weakSelf will get the height value much lower than 736 (iPhone 6s plus Screen Size). In my case, I got 672